### PR TITLE
Added only-files flag to exclude directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Both `--file` and `--not-file` can be used multiple times in one command. Think 
 
 `--run-js` - JavaScript command. Example: `console.log('{{src-file}}')` - the same as above
 
+`--not-file` - file anti-pattern. Example: `--not-file '**/*.min.js'`
+
+`--dot` - enable glob's `dot` setting to include names starting with dots, such as `.gitignore`. Example: `--file * --dot`
+
+`--only-files` - use with `--dot` to filter out non-file names, such as `.vscode/` directories. Example: `--file */* --dot --only-files`
+
 #### The following variables are available inside "run" and "run-js" strings:
 
 `{{src-file}}` - path to exact source file. Example: "./src/app/js/main.js"

--- a/run-for-every-file.js
+++ b/run-for-every-file.js
@@ -8,6 +8,7 @@
 
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 const execSync = require('child_process').execSync;
 const vm = require('vm');
@@ -95,6 +96,10 @@ function findFiles(srcDir, globPattern, globAntiPattern = '', globOptions = {}) 
         result = includeFiles;
     }
 
+    if (onlyFiles) {
+        result = includeFiles.filter((file) => fs.lstatSync(file).isFile());
+    }
+
     return result;
 }
 
@@ -122,12 +127,13 @@ const globAntiPattern = params['not-file'] || '';
 const command = params.run || params['run-js'] || null;
 const isJsCommand = 'run-js' in params;
 const isSilent = Boolean(params.silent);
-const includeDotFiles = Boolean(params.dot);
+const includeDots = Boolean(params.dot);
+const onlyFiles = Boolean(params["only-files"]);
 
 const globOptions = {
     mark: true,
     strict: true,
-    dot: includeDotFiles
+    dot: includeDots
 };
 
 if (!command) {


### PR DESCRIPTION
Glob will give back directories like `.vscode` when `dot` is true. This removes them with `lstatSync(file).isFile()`.

Fixes #1. 